### PR TITLE
Don't complain outside git repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v0.2.0 (unreleased)
 -------------------
 
 -   Commit SHas are now prefixed with ":".
+-   Don't complain outside git repositories.
 
 
 v0.1.1 (2017-10-29)

--- a/cmd/gitprompt/main.go
+++ b/cmd/gitprompt/main.go
@@ -30,7 +30,6 @@ var (
 
 func run() error {
 	cmd := exec.Command("git", "status", "--porcelain", "--branch")
-	cmd.Stderr = os.Stderr
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -117,12 +116,11 @@ func (s *Status) feed(line string) error {
 			s.Ahead = branch.Ahead
 			s.Behind = branch.Behind
 			return nil
-		} else {
-			var err error
-			s.Branch, err = getTagNameOrHash()
-			if err != nil {
-				return err
-			}
+		}
+
+		s.Branch, err = getTagNameOrHash()
+		if err != nil {
+			return err
 		}
 
 		return nil


### PR DESCRIPTION
We shouldn't print to stderr if gitprompt is called outside a git
repository.