### PR TITLE
Add -no-git-status flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Releases
 ========
 
+v0.4.0 (unreleased)
+-------------------
+
+-   Add `-no-git-status` flag that reports the branch, tag, or hash only. This
+    can be useful for large repositories.
+
+
 v0.3.1 (2019-08-16)
 -------------------
 

--- a/commit.go
+++ b/commit.go
@@ -1,37 +1,48 @@
 package gitprompt
 
 import (
-	"errors"
 	"strings"
 )
 
 // Commit contains information about a commit if we're not no a branch.
 type Commit struct {
 	ShortID string
+	Branch  string
 	Tags    []string
 }
 
-const _tag = "tag:"
+const (
+	_tag       = "tag: "
+	_headPoint = "HEAD -> "
+)
 
 // ReadCommit reads the output of `git log -1 --format=%h%d`.
 func ReadCommit(l string) (Commit, error) {
 	// We get something like,
 	//   abcdef1 (HEAD, tag: foo, tag: bar)
+	//   abcdef1 (HEAD -> master, origin/master, tag: bar)
 
 	var c Commit
 	if i := strings.IndexByte(l, ' '); i >= 0 {
 		c.ShortID = l[:i]
 		l = l[i+1:]
 	} else {
-		return c, errors.New("failed to read commit ID")
+		// Just "abcdef1".
+		c.ShortID = l
+		return c, nil
 	}
 
 	// (HEAD, tag: foo, tag: bar)
+	// (HEAD -> master, tag: foo, tag: bar)
 	l = l[1 : len(l)-1] // drop ( )
 	for _, n := range strings.Split(l, ", ") {
-		if i := strings.Index(n, _tag); i >= 0 {
-			i += len(_tag) + 1
-			c.Tags = append(c.Tags, n[i:])
+		switch {
+		case strings.HasPrefix(n, _tag):
+			tag := n[len(_tag):]
+			c.Tags = append(c.Tags, tag)
+		case strings.HasPrefix(n, _headPoint):
+			branch := n[len(_headPoint):]
+			c.Branch = branch
 		}
 	}
 

--- a/commit_test.go
+++ b/commit_test.go
@@ -1,0 +1,51 @@
+package gitprompt
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReadCommit(t *testing.T) {
+	tests := []struct {
+		desc string
+		give string
+		want Commit
+	}{
+		{
+			desc: "hash only",
+			give: "abcdef",
+			want: Commit{ShortID: "abcdef"},
+		},
+		{
+			desc: "hash and tags",
+			give: "abcdef (HEAD, tag: foo, tag: bar/baz)",
+			want: Commit{
+				ShortID: "abcdef",
+				Tags:    []string{"foo", "bar/baz"},
+			},
+		},
+		{
+			desc: "branch",
+			give: "abcdef (HEAD -> master, origin/master, tag: foo)",
+			want: Commit{
+				ShortID: "abcdef",
+				Branch:  "master",
+				Tags:    []string{"foo"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := ReadCommit(tt.give)
+			if err != nil {
+				t.Errorf("ReadCommit(%q) = %v", tt.give, err)
+				return
+			}
+
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Errorf("ReadCommit(%q) = %#v != %#v", tt.give, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a `no-git-status` flag that reports the branch name, tag name,
or commit hash without calling `git status`.

It defaults to true if `GITPROMPT_NO_GIT_STATUS=1`.

This will be faster in large repositories where `git status` is
expensive.