### PR TITLE
Escape zero-width characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Releases
 ========
 
+v0.5.0 (unreleased)
+-------------------
+
+-   **Breaking**: Either `zsh` or `bash` must be specified as a positional
+    argument to `gitprompt`.
+-   Escape zero-width characters so that tab completion behaves properly.
+
+
 v0.4.0 (2020-03-04)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 [![Build Status](https://travis-ci.org/abhinav/gitprompt.svg?branch=master)](https://travis-ci.org/abhinav/gitprompt)
 
-Introduction
-============
+# Introduction
 
 `gitprompt` provides a prompt component for Zsh and Bash which contains
 information about a git repository. The behavior of `gitprompt` is inspired by
 [olivierverdier/zsh-git-prompt] and the [oh-my-zsh plugin] for it.
 
-Installation
-============
+# Installation
 
-Binaries
---------
+## Binaries
+
 
 Pre-built ARM and 64-bit binaries are available for Linux and Mac at
 <https://github.com/abhinav/gitprompt/releases>. To install, simply unpack the
@@ -25,34 +23,58 @@ For example, if you have `$HOME/bin` on your `$PATH`,
     URL="https://github.com/abhinav/gitprompt/releases/download/$VERSION/gitprompt.$VERSION.$OS.$ARCH.tar.gz"
     curl -L "$URL" | tar xzv -C ~/bin
 
-Build From Source
------------------
+## Build From Source
 
 If you have Go installed, you can install `gitprompt` from source using the
 following command.
 
     $ go get -u github.com/abhinav/gitprompt/cmd/gitprompt
 
-Usage
-=====
+# Usage
 
-In either Bash or Zsh, add `$(gitprompt)` to your prompt. Be sure to escape it
-so that the command isn't executed when you're declaring the prompt.
-
-For example, in Bash, you can add the following to your .bashrc.
+In Zsh, add `$(gitprompt zsh)` to your prompt. For example, add the following
+to your `~/.zshrc`.
 
 ```sh
-PS1='\h:\W $(gitprompt) $ '
+PROMPT='%M:%~ $(gitprompt zsh) $ '
 ```
 
-Similarly, in Zsh, you can add the following to your .zshrc.
+In Bash, add `$(gitprompt bash)` to your prompt. For example, add the
+following to your `~/.bashrc`.
 
 ```sh
-PROMPT='%M:%~ $(gitprompt) $ '
+PS1='\h:\W $(gitprompt bash) $ '
 ```
 
-Credits
-=======
+Note that in both cases, the `$(gitprompt ...)` command must be escaped so
+that it is not run during prompt declaration. To do this, declare the prompt
+with single quotes as done above, or escape the `$` if you're using double
+quotes:
+
+```sh
+PROMPT="%M:%~ \$(gitprompt zsh) $ "
+```
+
+## Large repositories
+
+If you're working inside a large repository where running `git status` takes
+too long, use the `-no-git-status` flag with `gitprompt`.
+
+```sh
+PROMPT='%M:%~ $(gitprompt -no-git-status zsh) $ '
+```
+
+With this flag enabled, only minimal information about the current branch,
+tag, or commit hash will be displayed. This is a relatively cheap and fast
+operation.
+
+This flag defaults to true if the `GITPROMPT_NO_GIT_STATUS` environment
+variable is set. Mixing the environment variable with [direnv], you can
+configure this flag on a per-directory basis if necessary.
+
+  [direnv]: https://direnv.net/
+
+# Credits
 
 The functionality provided by `gitprompt` is inspired by
 [olivierverdier/zsh-git-prompt] and the [oh-my-zsh plugin] for it.

--- a/cmd/gitprompt/main.go
+++ b/cmd/gitprompt/main.go
@@ -2,42 +2,99 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/abhinav/gitprompt"
-	"github.com/fatih/color"
 )
 
 func main() {
-	color.NoColor = false
 	log.SetFlags(0)
-	if err := run(os.Args[1:]); err != nil {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
 		log.Fatal(err)
 	}
 }
 
+type color []byte
+
 var (
-	branchColor   = color.New(color.FgMagenta, color.Bold)
-	stagedColor   = color.New(color.FgRed)
-	conflictColor = color.New(color.FgRed)
-	changedColor  = color.New(color.FgBlue)
-	cleanColor    = color.New(color.FgGreen)
+	_branchColor   = color("\x1b[35;1m") // magenta; bold
+	_stagedColor   = color("\x1b[31m")   // red
+	_conflictColor = _stagedColor        // red
+	_changedColor  = color("\x1b[34m")   // blue
+	_cleanColor    = color("\x1b[32m")   // green
+
+	_reset = color("\x1b[0m")
 )
 
-func run(args []string) error {
+type shell struct {
+	// Byte sequences to write before and after each zero-width sequence
+	// of characters in the prompt.
+	ZWOpen, ZWClose []byte
+}
+
+var (
+	_zsh  = shell{ZWOpen: []byte("%{"), ZWClose: []byte("%}")}
+	_bash = shell{ZWOpen: []byte{0x01}, ZWClose: []byte{0x02}}
+)
+
+type promptBuffer struct {
+	bytes.Buffer
+
+	Shell shell
+
+	// Used for AppendInt.
+	intbuff [4]byte
+}
+
+func (w *promptBuffer) Itoa(i int64) {
+	w.Write(strconv.AppendInt(w.intbuff[:0], i, 10))
+}
+
+func (w *promptBuffer) Color(c color) {
+	w.Write(w.Shell.ZWOpen)
+	w.Write(c)
+	w.Write(w.Shell.ZWClose)
+}
+
+func (w *promptBuffer) Reset() {
+	w.Color(_reset)
+}
+
+const (
+	_check    = '✔'
+	_cross    = '✖'
+	_dot      = '●'
+	_dots     = '…'
+	_down     = '↓'
+	_parClose = ')'
+	_parOpen  = '('
+	_pipe     = '|'
+	_plus     = '✚'
+	_up       = '↑'
+)
+
+func run(args []string, stdout io.Writer) error {
 	var (
 		timeout  time.Duration
 		noStatus bool
 	)
 
 	flag := flag.NewFlagSet("gitprompt", flag.ContinueOnError)
+	flag.Usage = func() {
+		fmt.Fprintf(flag.Output(), "usage: %v shell\n", flag.Name())
+		flag.PrintDefaults()
+	}
+
 	flag.DurationVar(&timeout, "timeout", 0,
 		"amount of time the 'git status' command is allowed to take; unlimited if 0")
 
@@ -46,6 +103,21 @@ func run(args []string) error {
 
 	if err := flag.Parse(args); err != nil {
 		return err
+	}
+
+	if flag.NArg() == 0 {
+		flag.Usage()
+		return nil
+	}
+
+	var shell shell
+	switch flag.Arg(0) {
+	case "bash":
+		shell = _bash
+	case "zsh":
+		shell = _zsh
+	default:
+		return fmt.Errorf("unsupported shell %q", flag.Arg(0))
 	}
 
 	ctx := context.Background()
@@ -71,44 +143,69 @@ func run(args []string) error {
 		return nil // not a git repo
 	}
 
-	fmt.Printf("(%v", branchColor.Sprint(s.Branch))
-	defer fmt.Print(")")
+	w := promptBuffer{Shell: shell}
+	buildPrompt(&w, s)
+	w.WriteTo(stdout)
+	return nil
+}
+
+func buildPrompt(w *promptBuffer, s *Status) {
+	w.WriteRune(_parOpen)
+	defer w.WriteRune(_parClose)
+
+	w.Color(_branchColor)
+	w.WriteString(s.Branch)
+	w.Reset()
 
 	if s.BranchOnly {
-		return nil
+		return
 	}
 
 	if s.Behind > 0 {
-		fmt.Printf("↓%d", s.Behind)
+		w.WriteRune(_down)
+		w.Itoa(s.Behind)
 	}
+
 	if s.Ahead > 0 {
-		fmt.Printf("↑%d", s.Ahead)
+		w.WriteRune(_up)
+		w.Itoa(s.Ahead)
 	}
-	fmt.Printf("|")
+
+	w.WriteRune(_pipe)
 
 	if s.Staged > 0 {
-		stagedColor.Printf("●%d", s.Staged)
+		w.Color(_stagedColor)
+		w.WriteRune(_dot)
+		w.Itoa(s.Staged)
+		w.Reset()
 	}
 
 	if s.Conflicts > 0 {
-		conflictColor.Printf("✖%d", s.Conflicts)
+		w.Color(_conflictColor)
+		w.WriteRune(_cross)
+		w.Itoa(s.Conflicts)
+		w.Reset()
 	}
 
 	if s.Changed > 0 {
-		changedColor.Printf("✚%d", s.Changed)
+		w.Color(_changedColor)
+		w.WriteRune(_plus)
+		w.Itoa(s.Changed)
+		w.Reset()
 	}
 
 	if s.Untracked > 0 {
-		fmt.Printf("…%d", s.Untracked)
+		w.WriteRune(_dots)
+		w.Itoa(s.Untracked)
 	}
 
 	switch {
 	case s.Changed > 0, s.Conflicts > 0, s.Staged > 0, s.Untracked > 0:
 	default:
-		cleanColor.Printf("✔")
+		w.Color(_cleanColor)
+		w.WriteRune(_check)
+		w.Reset()
 	}
-
-	return nil
 }
 
 func gitStatus(ctx context.Context) (*Status, error) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/abhinav/gitprompt
 go 1.12
 
 require (
-	github.com/fatih/color v1.5.0
 	github.com/tcnksm/ghr v0.13.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	honnef.co/go/tools v0.0.1-2020.1.3

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Songmu/retry v0.1.0 h1:hPA5xybQsksLR/ry/+t/7cFajPW+dqjmjhzZhioBILA=
 github.com/Songmu/retry v0.1.0/go.mod h1:7sXIW7eseB9fq0FUvigRcQMVLR9tuHI0Scok+rkpAuA=
-github.com/fatih/color v1.5.0 h1:vBh+kQp8lg9XPr56u1CPrWjFXtdphMoGWVHr9/1c+A0=
-github.com/fatih/color v1.5.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=


### PR DESCRIPTION
If gitprompt is used in a single-line prompt, it makes tab completion
behave poorly. For example, when the prompt says,

    (master|✔) $ ls |

Pressing tab at this point will fire the tab completion behavior, but
it will then indent the ls a few characters, leaving a copy of the old
one in place.

    (master|✔) $ ls                  ls |

This is because the position of the cursor is calculated based on the
length of the propmpt text. Zsh and Bash don't realize that the escape
codes in the output do not add to the length of the text.

Zsh supports `%{...%}` in prompts which treats the contents inside the
braces as a zero-width escape sequence.
See also http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Visual-effects.

Similarly, Bash supports `\[...\]` for a similar purpose, however that's
just short for `\001` and `\002`.
See also https://stackoverflow.com/a/32267141.

This changes gitprompt to support both forms of escapes to make
gitprompt play nicely with tab completion on single-line prompts.
In the process, this drops the dependency on fatih/color, and instead
manages colors locally.

And while at it, this also speeds up the command by using more efficient
operations to build the prompt components.

Before:

```
$ hyperfine './gitprompt zsh'
Benchmark #1: ./gitprompt zsh
  Time (mean ± σ):      91.6 ms ±   2.7 ms    [User: 9.7 ms, System: 77.9 ms]
  Range (min … max):    88.7 ms …  99.2 ms    31 runs
```

After:

```
$ hyperfine './gitprompt zsh'
Benchmark #1: ./gitprompt zsh
  Time (mean ± σ):      49.3 ms ±   2.2 ms    [User: 6.0 ms, System: 40.5 ms]
  Range (min … max):    45.2 ms …  55.3 ms    55 runs
```