### PR TITLE
Faster gitprompt -no-git-status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Releases
 ========
 
+v0.6.0 (unreleased)
+-------------------
+
+-   Make `gitprompt -no-git-status` faster by dropping reliance on `git log`.
+
+
 v0.5.0 (2020-04-30)
 -------------------
 


### PR DESCRIPTION
Even `gitprompt -no-git-status` takes really long on large repositories
because of its reliance on `git log`.

I found it faster to call `git rev-parse` twice and get the branch name
or commit ID from that.
